### PR TITLE
Refactor Open5GS startup to per-NF configs

### DIFF
--- a/CoreFuzzer/Dockerfile
+++ b/CoreFuzzer/Dockerfile
@@ -35,6 +35,7 @@ RUN meson build --prefix=/ -Db_coverage=true && \
     ninja -C build
 RUN cd build && ninja install && cd .. && cp build/tests/app/5gc /usr/bin/
 COPY sample.yaml /corefuzzer_deps/open5gs/build/configs/sample.yaml
+COPY nf_configs /corefuzzer_deps/open5gs/build/configs/nf_configs
 
 # Install UERANSIM
 WORKDIR /corefuzzer_deps

--- a/CoreFuzzer/nf_configs/amf.yaml
+++ b/CoreFuzzer/nf_configs/amf.yaml
@@ -1,0 +1,35 @@
+amf:
+    logger:
+      file: __LOG_DIR__/amf.log
+    sbi:
+      - addr: 127.0.0.5
+        port: 7777
+    ngap:
+      - addr: 127.0.0.5
+    metrics:
+      addr: 127.0.0.5
+      port: 9090
+    guami:
+      - plmn_id:
+          mcc: 999
+          mnc: 70
+        amf_id:
+          region: 2
+          set: 1
+    tai:
+      - plmn_id:
+          mcc: 999
+          mnc: 70
+        tac: 1
+    plmn_support:
+      - plmn_id:
+          mcc: 999
+          mnc: 70
+        s_nssai:
+          - sst: 1
+    security:
+        integrity_order : [ NIA2, NIA1, NIA0 ]
+        ciphering_order : [ NEA2, NEA1, NEA0 ]
+    network_name:
+        full: Open5GS
+    amf_name: open5gs-amf0

--- a/CoreFuzzer/nf_configs/ausf.yaml
+++ b/CoreFuzzer/nf_configs/ausf.yaml
@@ -1,0 +1,6 @@
+ausf:
+    logger:
+      file: __LOG_DIR__/ausf.log
+    sbi:
+      - addr: 127.0.0.11
+        port: 7777

--- a/CoreFuzzer/nf_configs/bsf.yaml
+++ b/CoreFuzzer/nf_configs/bsf.yaml
@@ -1,0 +1,6 @@
+bsf:
+    logger:
+      file: __LOG_DIR__/bsf.log
+    sbi:
+      - addr: 127.0.0.15
+        port: 7777

--- a/CoreFuzzer/nf_configs/nrf.yaml
+++ b/CoreFuzzer/nf_configs/nrf.yaml
@@ -1,0 +1,8 @@
+nrf:
+    logger:
+      file: __LOG_DIR__/nrf.log
+    sbi:
+      - addr:
+        - 127.0.0.10
+        # - ::1
+        port: 7777

--- a/CoreFuzzer/nf_configs/nssf.yaml
+++ b/CoreFuzzer/nf_configs/nssf.yaml
@@ -1,0 +1,11 @@
+nssf:
+    logger:
+      file: __LOG_DIR__/nssf.log
+    sbi:
+      - addr: 127.0.0.14
+        port: 7777
+    nsi:
+      - addr: 127.0.0.10
+        port: 7777
+        s_nssai:
+          sst: 1

--- a/CoreFuzzer/nf_configs/pcf.yaml
+++ b/CoreFuzzer/nf_configs/pcf.yaml
@@ -1,0 +1,9 @@
+pcf:
+    logger:
+      file: __LOG_DIR__/pcf.log
+    sbi:
+      - addr: 127.0.0.13
+        port: 7777
+    metrics:
+      - addr: 127.0.0.13
+        port: 9090

--- a/CoreFuzzer/nf_configs/scp.yaml
+++ b/CoreFuzzer/nf_configs/scp.yaml
@@ -1,0 +1,6 @@
+scp:
+    logger:
+      file: __LOG_DIR__/scp.log
+    sbi:
+      - addr: 127.0.1.10
+        port: 7777

--- a/CoreFuzzer/nf_configs/smf.yaml
+++ b/CoreFuzzer/nf_configs/smf.yaml
@@ -1,0 +1,43 @@
+smf:
+    logger:
+      file: __LOG_DIR__/smf.log
+    sbi:
+      - addr: 127.0.0.4
+        port: 7777
+    pfcp:
+      - addr: 127.0.0.4
+    gtpc:
+      - addr: 127.0.0.4
+      # - addr: ::1
+    gtpu:
+      - addr: 127.0.0.4
+      # - addr: ::1
+    metrics:
+      addr: 127.0.0.4
+      port: 9090
+    subnet:
+      - addr: 10.45.0.1/16
+      # - addr: 2001:db8:cafe::1/48
+    dns:
+      - 8.8.8.8
+      - 8.8.4.4
+      # - 2001:4860:4860::8888
+      # - 2001:4860:4860::8844
+    mtu: 1400
+    freeDiameter:
+      identity: smf.localdomain
+      realm: localdomain
+      listen_on: 127.0.0.4
+      no_fwd: true
+      load_extension:
+        - module: /corefuzzer_deps/open5gs/build/subprojects/freeDiameter/extensions/dbg_msg_dumps.fdx
+          conf: 0x8888
+        - module: /corefuzzer_deps/open5gs/build/subprojects/freeDiameter/extensions/dict_rfc5777.fdx
+        - module: /corefuzzer_deps/open5gs/build/subprojects/freeDiameter/extensions/dict_mip6i.fdx
+        - module: /corefuzzer_deps/open5gs/build/subprojects/freeDiameter/extensions/dict_nasreq.fdx
+        - module: /corefuzzer_deps/open5gs/build/subprojects/freeDiameter/extensions/dict_nas_mipv6.fdx
+        - module: /corefuzzer_deps/open5gs/build/subprojects/freeDiameter/extensions/dict_dcca.fdx
+        - module: /corefuzzer_deps/open5gs/build/subprojects/freeDiameter/extensions/dict_dcca_3gpp/dict_dcca_3gpp.fdx
+      connect:
+        - identity: pcrf.localdomain
+          addr: 127.0.0.9

--- a/CoreFuzzer/nf_configs/udm.yaml
+++ b/CoreFuzzer/nf_configs/udm.yaml
@@ -1,0 +1,13 @@
+udm:
+    logger:
+      file: __LOG_DIR__/udm.log
+    hnet:
+      - id: 1
+        scheme: 1
+        key: /corefuzzer_deps/open5gs/build/configs/open5gs/hnet/curve25519-1.key
+      - id: 2
+        scheme: 2
+        key: /corefuzzer_deps/open5gs/build/configs/open5gs/hnet/secp256r1-2.key
+    sbi:
+      - addr: 127.0.0.12
+        port: 7777

--- a/CoreFuzzer/nf_configs/udr.yaml
+++ b/CoreFuzzer/nf_configs/udr.yaml
@@ -1,0 +1,6 @@
+udr:
+    logger:
+      file: __LOG_DIR__/udr.log
+    sbi:
+      - addr: 127.0.0.20
+        port: 7777

--- a/CoreFuzzer/nf_configs/upf.yaml
+++ b/CoreFuzzer/nf_configs/upf.yaml
@@ -1,0 +1,13 @@
+upf:
+    logger:
+      file: __LOG_DIR__/upf.log
+    pfcp:
+      - addr: 127.0.0.7
+    gtpu:
+      - addr: 127.0.0.7
+    subnet:
+      - addr: 10.45.0.1/16
+      # - addr: 2001:db8:cafe::1/48
+    metrics:
+      - addr: 127.0.0.7
+        port: 9090


### PR DESCRIPTION
## Summary
- add dedicated nf_configs YAML templates for each Open5GS network function
- copy the new configuration directory into the container image during build
- launch and manage individual Open5GS binaries with per-NF log files instead of 5gc

## Testing
- python3 -m compileall CoreFuzzer/setup_helper.py

------
https://chatgpt.com/codex/tasks/task_e_68c9f3dc38548329b1c45a61697a89b3